### PR TITLE
Fix type discrepancy between ui.h and ui.c

### DIFF
--- a/lib/pacutils/ui.h
+++ b/lib/pacutils/ui.h
@@ -31,12 +31,12 @@ void pu_ui_error(const char *fmt, ...);
 void pu_ui_warn(const char *fmt, ...);
 void pu_ui_notice(const char *fmt, ...);
 
-void pu_ui_verror(const char *fmt, ...);
-void pu_ui_vwarn(const char *fmt, ...);
-void pu_ui_vnotice(const char *fmt, ...);
+void pu_ui_verror(const char *fmt, va_list args);
+void pu_ui_vwarn(const char *fmt, va_list args);
+void pu_ui_vnotice(const char *fmt, va_list args);
 
 int pu_ui_confirm(int def, const char *prompt, ...);
-int pu_ui_select_index(long def, long min, long max, const char *prompt, ...);
+long pu_ui_select_index(long def, long min, long max, const char *prompt, ...);
 
 const char *pu_ui_msg_progress(alpm_progress_t event);
 


### PR DESCRIPTION
Noticed because I was using `pacutils-git` from AUR for some forgotten reason. Switched to `community/pacutils` now, but might as well push a fix.