### PR TITLE
Check if stdin is a tty before initializing libalpm

### DIFF
--- a/src/paccheck.c
+++ b/src/paccheck.c
@@ -778,6 +778,7 @@ void add_deps(alpm_pkg_t *pkg) {
 int main(int argc, char **argv) {
   alpm_list_t *i;
   int ret = 0;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   if (!(config = parse_opts(argc, argv))) {
     ret = 1;
@@ -800,7 +801,7 @@ int main(int argc, char **argv) {
   for (; optind < argc; ++optind) {
     if (load_pkg(argv[optind]) == NULL) { ret = 1; }
   }
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     char *buf = NULL;
     size_t len = 0;
     ssize_t read;

--- a/src/pacinfo.c
+++ b/src/pacinfo.c
@@ -474,6 +474,7 @@ void cb_log(void *ctx, alpm_loglevel_t level, const char *fmt, va_list args) {
 
 int main(int argc, char **argv) {
   int ret = 0;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   if (!(config = parse_opts(argc, argv))) {
     goto cleanup;
@@ -506,7 +507,7 @@ int main(int argc, char **argv) {
     if (print_pkgspec_info(*argv) != 0) { ret = 1; }
   }
 
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     char *buf = NULL;
     size_t len = 0;
     ssize_t read;

--- a/src/paclog.c
+++ b/src/paclog.c
@@ -316,13 +316,14 @@ int main(int argc, char **argv) {
   alpm_list_t *i, *entries = NULL;
   FILE *f;
   int ret = 0;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   parse_opts(argc, argv);
   if (color == 1 && !isatty(fileno(stdout))) {
     color = 0;
   }
 
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     free(logfile);
     logfile = strdup("<stdin>");
     f = stdin;

--- a/src/pacrepairdb.c
+++ b/src/pacrepairdb.c
@@ -539,6 +539,7 @@ int main(int argc, char **argv) {
   int ret = 0;
   alpm_db_t *localdb;
   alpm_list_t *cache_pkgs = NULL, *packages = NULL, *i;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   if (!(config = parse_opts(argc, argv))) {
     ret = 1;
@@ -576,7 +577,7 @@ int main(int argc, char **argv) {
     }
     optind++;
   }
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     char *buf = NULL;
     size_t len = 0;
     ssize_t read;

--- a/src/pacrepairfile.c
+++ b/src/pacrepairfile.c
@@ -341,6 +341,7 @@ int fix_file(const char *file) {
 
 int main(int argc, char **argv) {
   int ret = 0;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   if (!(config = parse_opts(argc, argv))) {
     ret = 1;
@@ -380,7 +381,7 @@ int main(int argc, char **argv) {
   while (optind < argc) {
     if (fix_file(argv[optind++]) != 0 ) { ret = 1; }
   }
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     char *buf = NULL;
     size_t blen = 0;
     ssize_t len;

--- a/src/pacsift.c
+++ b/src/pacsift.c
@@ -895,6 +895,7 @@ void free_pkg(alpm_pkg_t *p) {
 int main(int argc, char **argv) {
   alpm_list_t *haystack = NULL, *matches = NULL, *i;
   int ret = 0;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   if (!(config = parse_opts(argc, argv))) {
     goto cleanup;
@@ -923,7 +924,7 @@ int main(int argc, char **argv) {
     goto cleanup;
   }
 
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     char *buf = NULL;
     size_t len = 0;
     ssize_t read;

--- a/src/pactrans.c
+++ b/src/pactrans.c
@@ -818,6 +818,7 @@ void cb_question(void *ctx, alpm_question_t *question) {
 int main(int argc, char **argv) {
   alpm_list_t *i, *err_data = NULL;
   int ret = 0;
+  int have_stdin = !isatty(fileno(stdin)) && errno != EBADF;
 
   myname = pu_basename(argv[0]);
   if (strcasecmp(myname, "pacinstall") == 0) {
@@ -830,7 +831,7 @@ int main(int argc, char **argv) {
     goto cleanup;
   }
 
-  if (!isatty(fileno(stdin)) && errno != EBADF) {
+  if (have_stdin) {
     char *buf = NULL;
     size_t len = 0;
     ssize_t read;


### PR DESCRIPTION
```
Using the recommended pattern of invoking pacsift et al with <&-
causes the file descriptor 0 to not be valid. However, this also makes
it available for being allocated by calls to open or socket.

While this pattern worked as expected with previous versions of
pacman/libalpm, this is no longer true, as alpm_initialize now creates
a socket, which is allocated at file descriptor 0 if it is free. This
causes the isatty check to now fail with ENOTTY instead of EBADF,
causing the tools to think they were invoked with a list of packages
on their standard input.

Fix this by moving the stdin check at the top of each program, before
any other initialization. (For consistency, this was done whether or
not the program's initialization involves libalpm.)
```

This is blocking aconfmgr and should fix https://github.com/AladW/aurutils/issues/804.

Thanks!