### PR TITLE
cast isspace parameters to unsigned char

### DIFF
--- a/lib/pacutils/mtree.c
+++ b/lib/pacutils/mtree.c
@@ -167,7 +167,7 @@ pu_mtree_t *pu_mtree_reader_next(pu_mtree_reader_t *reader, pu_mtree_t *dest) {
   if (reader->_buf[len - 1] == '\n') { reader->_buf[len - 1] = '\0'; }
 
   c = reader->_buf;
-  while (isspace(*c)) { c++; }
+  while (isspace((unsigned char)*c)) { c++; }
 
   if (c[0] == '#') {
     return pu_mtree_reader_next(reader, dest);
@@ -176,7 +176,7 @@ pu_mtree_t *pu_mtree_reader_next(pu_mtree_reader_t *reader, pu_mtree_t *dest) {
     c += 5;
   } else {
     char *sep = c, *path;
-    while (*sep && !isspace(*sep)) { sep++; }
+    while (*sep && !isspace((unsigned char)*sep)) { sep++; }
     if ((path = _pu_mtree_path(c, sep)) == NULL) { return NULL; }
     if (entry) {
       free(entry->path);

--- a/src/pacsift.c
+++ b/src/pacsift.c
@@ -290,7 +290,7 @@ struct size_cmp *parse_size(const char *str) {
   }
 
   if (bytes > 0) {
-    while (isspace(*end)) { end++; }
+    while (isspace((unsigned char)*end)) { end++; }
     if (*end && !parse_size_units(&size.bytes, bytes, end)) {
       fprintf(stderr, "error: invalid size comparison '%s'\n", str);
       cleanup(1);


### PR DESCRIPTION
This is a known C pitfall, and was causing an error on MSYS2.

See for example https://wiki.sei.cmu.edu/confluence/display/c/STR37-C.+Arguments+to+character-handling+functions+must+be+representable+as+an+unsigned+char