### PR TITLE
cast time_t to size_t for printf

### DIFF
--- a/src/pacrepairfile.c
+++ b/src/pacrepairfile.c
@@ -195,7 +195,7 @@ int fix_mtime(const char *path, struct archive_entry *entry) {
         path, strerror(errno));
     return 1;
   } else if (verbose) {
-    printf("%s: set modification time to %zu\n", path, t);
+    printf("%s: set modification time to %zu\n", path, (size_t)t);
   }
 
   return 0;


### PR DESCRIPTION
the format string was using `%zu`, which expects its argument to be a `size_t`, but `time_t` may be a different type, triggering for example `-Wformat` or `-Wformat-signedness`.

This was causing a build error on MSYS2.