### PR TITLE
Check the symlink itself, not the target of the symlink. Fixes issue #52

### DIFF
--- a/src/pacreport.c
+++ b/src/pacreport.c
@@ -350,6 +350,7 @@ void print_missing_files(alpm_handle_t *handle) {
   alpm_db_t *localdb = alpm_get_localdb(handle);
   alpm_list_t *matches = NULL, *p, *pkgs = alpm_db_get_pkgcache(localdb);
   char path[PATH_MAX], *tail;
+  struct stat statbuf;
   strncpy(path, alpm_option_get_root(handle), PATH_MAX);
   size_t len = strlen(path);
   size_t max = PATH_MAX - len;
@@ -360,7 +361,7 @@ void print_missing_files(alpm_handle_t *handle) {
     size_t i;
     for (i = 0; i < files->count; ++i) {
       strncpy(tail, files->files[i].name, max);
-      if (access(path, F_OK) != 0) {
+      if (lstat(path, &statbuf) != 0) {
         struct pkg_file_t *mf = pkg_file_new(p->data, &files->files[i]);
         matches = alpm_list_add(matches, mf);
       }


### PR DESCRIPTION
Switch to using lstat() instead of access(). This fixes the issue of incorrectly reporting an installed broken symlink as a missing file. 

This can be triggered during normal operation by java-runtime-common, java-environment-common etc, as not all java version provides all binaries.

See also issue #52

I checked the performance impact of this, and there is basically none. If anything it is slightly faster:
```console
$ # Old version (access)
$ time src/pacreport --missing-files > /dev/null
user=0,59s system=0,51s cpu=99% total=1,107
$ time src/pacreport --missing-files > /dev/null
user=0,61s system=0,50s cpu=99% total=1,116
$ time src/pacreport --missing-files > /dev/null
user=0,63s system=0,49s cpu=99% total=1,123
$ time src/pacreport --missing-files > /dev/null
user=0,62s system=0,50s cpu=99% total=1,115

$ # New version (lstat)
$ time src/pacreport --missing-files > /dev/null
user=0,62s system=0,44s cpu=99% total=1,063
$ time src/pacreport --missing-files > /dev/null
user=0,65s system=0,41s cpu=99% total=1,062
$ time src/pacreport --missing-files > /dev/null
user=0,62s system=0,43s cpu=99% total=1,053
$ time src/pacreport --missing-files > /dev/null
user=0,63s system=0,43s cpu=99% total=1,062
```

It is not clear to me why it would be faster, other than having to output less lines (since the false positive java results are gone).

I have tested that the new version still correctly reports actually missing files (including cases where the symlink itself is missing).