### PR TITLE
Pacman 7.0.0 fixes

### DIFF
--- a/lib/pacutils/config.c
+++ b/lib/pacutils/config.c
@@ -264,6 +264,7 @@ pu_config_t *pu_config_new(void) {
 
   config->checkspace = PU_CONFIG_BOOL_UNSET;
   config->color = PU_CONFIG_BOOL_UNSET;
+  config->disablesandbox = PU_CONFIG_BOOL_UNSET;
   config->noprogressbar = PU_CONFIG_BOOL_UNSET;
   config->disabledownloadtimeout = PU_CONFIG_BOOL_UNSET;
   config->ilovecandy = PU_CONFIG_BOOL_UNSET;
@@ -566,6 +567,7 @@ void pu_config_merge(pu_config_t *dest, pu_config_t *src) {
   MERGEBOOL(dest->noprogressbar, src->noprogressbar);
   MERGEBOOL(dest->ilovecandy, src->ilovecandy);
   MERGEBOOL(dest->disabledownloadtimeout, src->disabledownloadtimeout);
+  MERGEBOOL(dest->disablesandbox, src->disablesandbox);
 
   MERGEVAL(dest->cleanmethod, src->cleanmethod);
   MERGEVAL(dest->paralleldownloads, src->paralleldownloads);
@@ -575,6 +577,7 @@ void pu_config_merge(pu_config_t *dest, pu_config_t *src) {
   MERGESTR(dest->logfile, src->logfile);
   MERGESTR(dest->gpgdir, src->gpgdir);
   MERGESTR(dest->xfercommand, src->xfercommand);
+  MERGESTR(dest->downloaduser, src->downloaduser);
 
   MERGELIST(dest->architectures, src->architectures);
   MERGELIST(dest->cachedirs, src->cachedirs);

--- a/lib/pacutils/config.c
+++ b/lib/pacutils/config.c
@@ -54,6 +54,9 @@ struct _pu_config_setting {
   {"DisableDownloadTimeout", PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT},
   {"ParallelDownloads",      PU_CONFIG_OPTION_PARALLELDOWNLOADS},
 
+  {"DisableSandbox", PU_CONFIG_OPTION_DISABLESANDBOX},
+  {"DownloadUser",   PU_CONFIG_OPTION_DOWNLOADUSER},
+
   {"SigLevel",        PU_CONFIG_OPTION_SIGLEVEL},
   {"LocalFileSigLevel",  PU_CONFIG_OPTION_LOCAL_SIGLEVEL},
   {"RemoteFileSigLevel", PU_CONFIG_OPTION_REMOTE_SIGLEVEL},
@@ -385,6 +388,9 @@ alpm_handle_t *pu_initialize_handle_from_config(pu_config_t *config) {
   alpm_option_set_usesyslog(handle, config->usesyslog);
   alpm_option_set_architectures(handle, config->architectures);
   alpm_option_set_disable_dl_timeout(handle, config->disabledownloadtimeout);
+
+  alpm_option_set_disable_sandbox(handle, config->disablesandbox);
+  alpm_option_set_sandboxuser(handle, config->downloaduser);
 
   alpm_option_set_default_siglevel(handle, config->siglevel);
   alpm_option_set_local_file_siglevel(handle, config->localfilesiglevel);
@@ -796,6 +802,12 @@ int pu_config_reader_next(pu_config_reader_t *reader) {
         case PU_CONFIG_OPTION_ARCHITECTURE:
           APPENDLIST(&config->architectures, mini->value);
           break;
+        case PU_CONFIG_OPTION_DOWNLOADUSER:
+          free(config->downloaduser);
+          if ((config->downloaduser = strdup(mini->value)) == NULL) {
+            _PU_ERR(reader, PU_CONFIG_READER_STATUS_ERROR);
+          }
+          break;
         case PU_CONFIG_OPTION_XFERCOMMAND:
           free(config->xfercommand);
           if ((config->xfercommand = strdup(mini->value)) == NULL) {
@@ -882,6 +894,9 @@ int pu_config_reader_next(pu_config_reader_t *reader) {
           break;
         case PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT:
           config->disabledownloadtimeout = 1;
+          break;
+        case PU_CONFIG_OPTION_DISABLESANDBOX:
+          config->disablesandbox = 1;
           break;
         default:
           reader->status = PU_CONFIG_READER_STATUS_UNKNOWN_OPTION;

--- a/lib/pacutils/config.h
+++ b/lib/pacutils/config.h
@@ -61,6 +61,9 @@ typedef enum pu_config_option_t {
 
   PU_CONFIG_OPTION_USAGE,
 
+  PU_CONFIG_OPTION_DOWNLOADUSER,
+  PU_CONFIG_OPTION_DISABLESANDBOX,
+
   PU_CONFIG_OPTION_INCLUDE
 } pu_config_option_t;
 
@@ -82,6 +85,7 @@ typedef struct pu_config_t {
   char *gpgdir;
   char *logfile;
   char *xfercommand;
+  char *downloaduser;
 
   int paralleldownloads;
 
@@ -92,6 +96,7 @@ typedef struct pu_config_t {
   pu_config_bool_t usesyslog;
   pu_config_bool_t verbosepkglists;
   pu_config_bool_t disabledownloadtimeout;
+  pu_config_bool_t disablesandbox;
 
   int siglevel;
   int localfilesiglevel;

--- a/src/pacconf.c
+++ b/src/pacconf.c
@@ -302,6 +302,8 @@ void dump_options(void) {
   show_list_str("Architecture", config->architectures);
 
   show_str("XferCommand", config->xfercommand);
+  show_str("DownloadUser", config->downloaduser);
+  show_bool("DisableSandbox", config->disablesandbox);
 
   show_bool("UseSyslog", config->usesyslog);
   show_bool("Color", config->color);

--- a/src/pacconf.c
+++ b/src/pacconf.c
@@ -400,6 +400,8 @@ int list_directives(alpm_list_t *directives) {
       show_str("GPGDir", config->gpgdir);
     } else if (strcasecmp(i->data, "LogFile") == 0) {
       show_str("LogFile", config->logfile);
+    } else if (strcasecmp(i->data, "DownloadUser") == 0) {
+      show_str("DownloadUser", config->downloaduser);
 
     } else if (strcasecmp(i->data, "HoldPkg") == 0) {
       show_list_str("HoldPkg", config->holdpkgs);
@@ -433,6 +435,8 @@ int list_directives(alpm_list_t *directives) {
     } else if (strcasecmp(i->data, "DisableDownloadTimeout") == 0) {
       show_bool("DisableDownloadTimeout", config->disabledownloadtimeout);
 
+    } else if (strcasecmp(i->data, "DisableSandbox") == 0) {
+      show_bool("DisableSandbox", config->disablesandbox);
     } else if (strcasecmp(i->data, "CleanMethod") == 0) {
       show_cleanmethod("CleanMethod", config->cleanmethod);
 


### PR DESCRIPTION
This PR should fix the issues I have mentioned in https://github.com/andrewgregory/pacutils/issues/76#issuecomment-2345066842, although I'm not much of a C programmer, so please double check everything!

```
$ LD_LIBRARY_PATH=lib/ ./src/pacconf --config=pacman.conf DisableSandbox DownloadUser
DisableSandbox
DownloadUser = alpm
$ LD_LIBRARY_PATH=lib/ ./src/pacconf --config=pacman.conf | grep -E "DisableSandbox|DownloadUser"
DownloadUser = alpm
DisableSandbox
```

- **fix that the options are not displayed**
- **add the sandbox directives to the query system**
